### PR TITLE
Add reducer and tests for runCode, combinedReducer

### DIFF
--- a/spec/redux/reducer-test.js
+++ b/spec/redux/reducer-test.js
@@ -2,30 +2,19 @@ import pyretReducer from '../../src/redux/reducer';
 import * as actType from '../../src/redux/action-types';
 
 describe("The reducer", () => {
+  var state;
+
+  beforeEach(() => {
+    state = pyretReducer(undefined,{});
+  });
 
   describe("handles loadApi calls", () => {
 
     it("and returns a state object", () => {
-      var nextState = pyretReducer(undefined,"");
-      expect(nextState).toEqual(jasmine.any(Object));
+      expect(state.loadApi).toEqual(jasmine.any(Object));
     });
 
     describe("and returns a state change", () => {
-      var state;
-
-      beforeEach(() => {
-        state = {
-          loadingApi: undefined,
-          runtimeApi: undefined,
-          errorApi: undefined,
-          runtimeStage: undefined,
-          ast: undefined,
-          bytecode: undefined,
-          result: undefined,
-          errorRun: undefined,
-          pausing: false
-        };
-      });
 
       const start = {type: actType.START_LOAD_RUNTIME};
       const finish = {type: actType.FINISH_LOAD_RUNTIME, payload: "loadedRuntimeApi"};
@@ -33,18 +22,18 @@ describe("The reducer", () => {
 
       it("for action type START_LOAD_RUNTIME", () => {
         var nextState = pyretReducer(state, start).loadApi;
-        expect(nextState.loadingApi).toEqual('starting');
+        expect(nextState.stage).toEqual('started');
       });
 
       it("for action type FINISH_LOAD_RUNTIME", () => {
         var nextState = pyretReducer(state, finish).loadApi;
-        expect(nextState.loadingApi).toEqual('finished');
-        expect(nextState.runtimeApi).toEqual(finish.payload);
+        expect(nextState.stage).toEqual('finished');
+        expect(nextState.runtime).toEqual(finish.payload);
       });
 
       it("for action type FAIL_LOAD_RUNTIME", () => {
         var nextState = pyretReducer(state, fail).loadApi;
-        expect(nextState.loadingApi).toEqual('failed');
+        expect(nextState.stage).toEqual('failed');
         expect(nextState.error).toEqual(fail.payload);
       });
     });
@@ -53,26 +42,10 @@ describe("The reducer", () => {
   describe("handles runCode calls", () => {
 
     it("and returns a state object ", () => {
-      var nextState = pyretReducer(undefined,"");
-      expect(nextState).toEqual(jasmine.any(Object));
+      expect(state.runCode).toEqual(jasmine.any(Object));
     });
 
     describe("and returns a state change", () => {
-      var state;
-
-      beforeEach(() => {
-        state = {
-          loadingApi: undefined,
-          runtimeApi: undefined,
-          errorApi: undefined,
-          runtimeStage: undefined,
-          ast: undefined,
-          bytecode: undefined,
-          result: undefined,
-          errorRun: undefined,
-          pausing: false
-        };
-      });
 
       const startParse = {type: actType.START_PARSE};
       const finishParse = {type: actType.FINISH_PARSE, payload: "ast"};
@@ -88,7 +61,7 @@ describe("The reducer", () => {
 
       it("for action type START_PARSE", () => {
         var nextState = pyretReducer(state, startParse).runCode;
-        expect(nextState.runtimeStage).toEqual('parsing');
+        expect(nextState.stage).toEqual('parsing');
       });
 
       it("for action type FINISH_PARSE", () => {
@@ -103,7 +76,7 @@ describe("The reducer", () => {
 
       it("for action type START_COMPILE", () => {
         var nextState = pyretReducer(state, startCompile).runCode;
-        expect(nextState.runtimeStage).toEqual('compiling');
+        expect(nextState.stage).toEqual('compiling');
       });
 
       it("for action type FINISH_COMPILE", () => {
@@ -118,7 +91,7 @@ describe("The reducer", () => {
 
       it("for action type START_EXECUTE", () => {
         var nextState = pyretReducer(state, startExecute).runCode;
-        expect(nextState.runtimeStage).toEqual('executing');
+        expect(nextState.stage).toEqual('executing');
       });
 
       it("for action type FINISH_EXECUTE", () => {

--- a/spec/redux/reducer-test.js
+++ b/spec/redux/reducer-test.js
@@ -1,43 +1,135 @@
-import loadApi from '../../src/redux/reducer';
+import pyretReducer from '../../src/redux/reducer';
 import * as actType from '../../src/redux/action-types';
 
 describe("The reducer", () => {
 
-  it("returns a state object", () => {
-    var nextState = loadApi(undefined,"");
-    expect(nextState).toEqual(jasmine.any(Object));
+  describe("handles loadApi calls", () => {
+
+    it("and returns a state object", () => {
+      var nextState = pyretReducer(undefined,"");
+      expect(nextState).toEqual(jasmine.any(Object));
+    });
+
+    describe("and returns a state change", () => {
+      var state;
+
+      beforeEach(() => {
+        state = {
+          loadingApi: undefined,
+          runtimeApi: undefined,
+          errorApi: undefined,
+          runtimeStage: undefined,
+          ast: undefined,
+          bytecode: undefined,
+          result: undefined,
+          errorRun: undefined,
+          pausing: false
+        };
+      });
+
+      const start = {type: actType.START_LOAD_RUNTIME};
+      const finish = {type: actType.FINISH_LOAD_RUNTIME, payload: "loadedRuntimeApi"};
+      const fail = {type: actType.FAIL_LOAD_RUNTIME, payload: "reason"};
+
+      it("for action type START_LOAD_RUNTIME", () => {
+        var nextState = pyretReducer(state, start).loadApi;
+        expect(nextState.loadingApi).toEqual('starting');
+      });
+
+      it("for action type FINISH_LOAD_RUNTIME", () => {
+        var nextState = pyretReducer(state, finish).loadApi;
+        expect(nextState.loadingApi).toEqual('finished');
+        expect(nextState.runtimeApi).toEqual(finish.payload);
+      });
+
+      it("for action type FAIL_LOAD_RUNTIME", () => {
+        var nextState = pyretReducer(state, fail).loadApi;
+        expect(nextState.loadingApi).toEqual('failed');
+        expect(nextState.error).toEqual(fail.payload);
+      });
+    });
   });
 
-  describe("returns a state change", () => {
-    var state;
+  describe("handles runCode calls", () => {
 
-    beforeEach(() => {
-      state = {
-        loadingApi: undefined,
-        runtimeApi: undefined,
-        error: undefined
-      };
+    it("and returns a state object ", () => {
+      var nextState = pyretReducer(undefined,"");
+      expect(nextState).toEqual(jasmine.any(Object));
     });
 
-    const start = {type: actType.START_LOAD_RUNTIME};
-    const finish = {type: actType.FINISH_LOAD_RUNTIME, payload: "loadedRuntimeApi"};
-    const fail = {type: actType.FAIL_LOAD_RUNTIME, payload: "reason"};
+    describe("and returns a state change", () => {
+      var state;
 
-    it("for action type START_LOAD_RUNTIME", () => {
-      var nextState = loadApi(state, start);
-      expect(nextState.loadingApi).toEqual('started');
-    });
+      beforeEach(() => {
+        state = {
+          loadingApi: undefined,
+          runtimeApi: undefined,
+          errorApi: undefined,
+          runtimeStage: undefined,
+          ast: undefined,
+          bytecode: undefined,
+          result: undefined,
+          errorRun: undefined,
+          pausing: false
+        };
+      });
 
-    it("for action type FINISH_LOAD_RUNTIME", () => {
-      var nextState = loadApi(state, finish);
-      expect(nextState.loadingApi).toEqual('finished');
-      expect(nextState.runtimeApi).toEqual(finish.payload);
-    });
+      const startParse = {type: actType.START_PARSE};
+      const finishParse = {type: actType.FINISH_PARSE, payload: "ast"};
+      const failParse = {type: actType.FAIL_PARSE, payload: "reason"};
 
-    it("for action type FAIL_LOAD_RUNTIME", () => {
-      var nextState = loadApi(state, fail);
-      expect(nextState.loadingApi).toEqual('failed');
-      expect(nextState.error).toEqual(fail.payload);
+      const startCompile = {type: actType.START_COMPILE};
+      const finishCompile = {type: actType.FINISH_COMPILE, payload: "bytecode"};
+      const failCompile = {type: actType.FAIL_COMPILE, payload: "reason"};
+
+      const startExecute = {type: actType.START_EXECUTE};
+      const finishExecute = {type: actType.FINISH_EXECUTE, payload: "result"};
+      const failExecute = {type: actType.FAIL_EXECUTE, payload: "reason"};
+
+      it("for action type START_PARSE", () => {
+        var nextState = pyretReducer(state, startParse).runCode;
+        expect(nextState.runtimeStage).toEqual('parsing');
+      });
+
+      it("for action type FINISH_PARSE", () => {
+        var nextState = pyretReducer(state, finishParse).runCode;
+        expect(nextState.ast).toEqual('ast');
+      });
+
+      it("for action type FAIL_PARSE", () => {
+        var nextState = pyretReducer(state, failParse).runCode;
+        expect(nextState.error).toEqual('reason');
+      });
+
+      it("for action type START_COMPILE", () => {
+        var nextState = pyretReducer(state, startCompile).runCode;
+        expect(nextState.runtimeStage).toEqual('compiling');
+      });
+
+      it("for action type FINISH_COMPILE", () => {
+        var nextState = pyretReducer(state, finishCompile).runCode;
+        expect(nextState.bytecode).toEqual('bytecode');
+      });
+
+      it("for action type FAIL_COMPILE", () => {
+        var nextState = pyretReducer(state, failCompile).runCode;
+        expect(nextState.error).toEqual('reason');
+      });
+
+      it("for action type START_EXECUTE", () => {
+        var nextState = pyretReducer(state, startExecute).runCode;
+        expect(nextState.runtimeStage).toEqual('executing');
+      });
+
+      it("for action type FINISH_EXECUTE", () => {
+        var nextState = pyretReducer(state, finishExecute).runCode;
+        expect(nextState.result).toEqual('result');
+      });
+
+      it("for action type FAIL_EXECUTE", () => {
+        var nextState = pyretReducer(state, failExecute).runCode;
+        expect(nextState.error).toEqual('reason');
+      });
     });
   });
 });

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,68 +1,69 @@
 import * as actType from './action-types';
 import { combineReducers } from 'redux';
 
-const loadApiState = {
-  loadingApi: undefined,
-  runtimeApi: undefined,
-  errorApi: undefined,
+const initialState = {
+  loadApi: {
+    stage: undefined,
+    runtime: undefined,
+    error: undefined,
+  },
+  runCode: {
+    stage: undefined,
+    ast: undefined,
+    bytecode: undefined,
+    result: undefined,
+    error: undefined,
+    pausing: false
+  }
 };
 
-const runCodeState = {
-  runtimeStage: undefined,
-  ast: undefined,
-  bytecode: undefined,
-  result: undefined,
-  errorRun: undefined,
-  pausing: false
-};
-
-function loadApi(state = loadApiState, action) {
+function loadApi(state = initialState.loadApi, action) {
   switch (action.type) {
     case actType.START_LOAD_RUNTIME:
-      return Object.assign({}, state, {loadingApi: 'started'});
+      return Object.assign({}, state, {stage: 'started'});
     case actType.FINISH_LOAD_RUNTIME:
-      return Object.assign({}, state, {loadingApi: 'finished', runtimeApi: action.payload});
+      return Object.assign({}, state, {stage: 'finished', runtime: action.payload});
     case actType.FAIL_LOAD_RUNTIME:
-      return Object.assign({}, state, {loadingApi: 'failed', error: action.payload});
+      return Object.assign({}, state, {stage: 'failed', error: action.payload});
     default:
       return state;
   }
 }
 
-function runCode(state = runCodeState, action) {
+function runCode(state = initialState.runCode, action) {
   switch (action.type) {
     case actType.START_PARSE:
-      return Object.assign({}, state, {runtimeStage: 'parsing'});
+      return Object.assign({}, state, {stage: 'parsing'});
     case actType.FINISH_PARSE:
       return Object.assign({}, state, {ast: action.payload});
     case actType.FAIL_PARSE:
       return Object.assign({}, state, {error: action.payload});
     case actType.START_COMPILE:
-      return Object.assign({}, state, {runtimeStage: 'compiling'});
+      return Object.assign({}, state, {stage: 'compiling'});
     case actType.FINISH_COMPILE:
       return Object.assign({}, state, {bytecode: action.payload});
     case actType.FAIL_COMPILE:
       return Object.assign({}, state, {error: action.payload});
     case actType.START_EXECUTE:
-      return Object.assign({}, state, {runtimeStage: 'executing'});
+      return Object.assign({}, state, {stage: 'executing'});
     case actType.FINISH_EXECUTE:
       return Object.assign({}, state, {result: action.payload});
     case actType.FAIL_EXECUTE:
       return Object.assign({}, state, {error: action.payload});
     case actType.STOP_RUN:
-      return Object.assign({}, state, {runtimeStage: 'stopping'});
+      return Object.assign({}, state, {stage: 'stopping'});
     case actType.PAUSE_RUN:
       return Object.assign({}, state, {pausing: true});
     case actType.CLEAR_STATE:
-      return Object.assign({}, runCodeState);
+      return Object.assign({}, state.runCode);
     default:
       return state;
   }
 }
 
 const pyretReducer = combineReducers({
-  runCode,
-  loadApi
+  loadApi,
+  runCode
 });
 
 export default pyretReducer;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,12 +1,22 @@
 import * as actType from './action-types';
+import { combineReducers } from 'redux';
 
-const initialState = {
+const loadApiState = {
   loadingApi: undefined,
   runtimeApi: undefined,
-  error: undefined
+  errorApi: undefined,
 };
 
-function loadApi(state = initialState, action) {
+const runCodeState = {
+  runtimeStage: undefined,
+  ast: undefined,
+  bytecode: undefined,
+  result: undefined,
+  errorRun: undefined,
+  pausing: false
+};
+
+function loadApi(state = loadApiState, action) {
   switch (action.type) {
     case actType.START_LOAD_RUNTIME:
       return Object.assign({}, state, {loadingApi: 'started'});
@@ -19,4 +29,40 @@ function loadApi(state = initialState, action) {
   }
 }
 
-export default loadApi;
+function runCode(state = runCodeState, action) {
+  switch (action.type) {
+    case actType.START_PARSE:
+      return Object.assign({}, state, {runtimeStage: 'parsing'});
+    case actType.FINISH_PARSE:
+      return Object.assign({}, state, {ast: action.payload});
+    case actType.FAIL_PARSE:
+      return Object.assign({}, state, {error: action.payload});
+    case actType.START_COMPILE:
+      return Object.assign({}, state, {runtimeStage: 'compiling'});
+    case actType.FINISH_COMPILE:
+      return Object.assign({}, state, {bytecode: action.payload});
+    case actType.FAIL_COMPILE:
+      return Object.assign({}, state, {error: action.payload});
+    case actType.START_EXECUTE:
+      return Object.assign({}, state, {runtimeStage: 'executing'});
+    case actType.FINISH_EXECUTE:
+      return Object.assign({}, state, {result: action.payload});
+    case actType.FAIL_EXECUTE:
+      return Object.assign({}, state, {error: action.payload});
+    case actType.STOP_RUN:
+      return Object.assign({}, state, {runtimeStage: 'stopping'});
+    case actType.PAUSE_RUN:
+      return Object.assign({}, state, {pausing: true});
+    case actType.CLEAR_STATE:
+      return Object.assign({}, runCodeState);
+    default:
+      return state;
+  }
+}
+
+const pyretReducer = combineReducers({
+  runCode,
+  loadApi
+});
+
+export default pyretReducer;


### PR DESCRIPTION
Logs error message

ERROR: 'Unexpected keys "loadingApi", "runtimeApi", "errorApi", "runtimeStage", "ast", "bytecode", "result", "errorRun", "pausing" found in previous state received by the reducer. Expected to find one of the known reducer keys instead: "runCode", "loadApi". Unexpected keys will be ignored.'

This seems to have something to do with the way combinedReducers() handles the state passed to it, and the key values stored in the object passed to the function. Not sure exactly how to fix, but the tests pass!