### PR TITLE
Blimpich error ui

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -6,27 +6,32 @@ import {styles} from './styles';
 import Toolbar from './Toolbar';
 import CodeWindow from './CodeWindow';
 import Spinner from './Spinner';
+import ErrorBox from './ErrorBox';
 
 class Editor extends React.Component {
   render() {
     return (
       <div>
-        <Toolbar logo="https://code.pyret.org/img/pyret-logo.png" />
-        {this.props.isLoadingRuntime &&
-         <Spinner style={styles.spinners.window} />
-        }
-        {this.props.hasLoadedRuntime &&
-         <div>
-           <SplitPane defaultSize="50%" split="vertical">
-             <div><CodeWindow/></div>
-             <div><p>{this.props.result}</p></div>
-           </SplitPane>
-         </div>
-        }
+          <Toolbar logo="https:code.pyret.org/img/pyret-logo.png" />
+          {this.props.isLoadingRuntime &&
+           <Spinner style={styles.spinners.window} />
+          }
+           {this.props.hasLoadedRuntime &&
+            <div>
+                <SplitPane defaultSize="50%" split="vertical">
+                    <div><CodeWindow/></div>
+                    <div>
+                        <ErrorBox/>
+                        <p>{this.props.result}</p>
+                    </div>
+                </SplitPane>
+            </div>
+           }
       </div>
     );
   }
 }
+
 
 Editor.propTypes = {
   isLoadingRuntime: React.PropTypes.bool,

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -12,33 +12,31 @@ class Editor extends React.Component {
   render() {
     return (
       <div>
-          <Toolbar logo="https:code.pyret.org/img/pyret-logo.png" />
-          {this.props.isLoadingRuntime &&
-           <Spinner style={styles.spinners.window} />
-          }
-           {this.props.hasLoadedRuntime &&
-            <div>
-                <SplitPane defaultSize="50%" split="vertical">
-                    <div><CodeWindow/></div>
-                    <div>
-                        <ErrorBox/>
-                        <p>{this.props.result}</p>
-                    </div>
-                </SplitPane>
-            </div>
-           }
+        <Toolbar logo="https://code.pyret.org/img/pyret-logo.png" />
+        {this.props.isLoadingRuntime &&
+         <Spinner style={styles.spinners.window} />
+        }
+        {this.props.hasLoadedRuntime &&
+         <div>
+           <SplitPane defaultSize="50%" split="vertical">
+             <div><CodeWindow/></div>
+             <div>
+               <ErrorBox/>
+               <p>{this.props.result}</p>
+             </div>
+           </SplitPane>
+         </div>
+        }
       </div>
     );
   }
 }
-
 
 Editor.propTypes = {
   isLoadingRuntime: React.PropTypes.bool,
   hasLoadedRuntime: React.PropTypes.bool,
   result: React.PropTypes.any,
 };
-
 
 export default connect(
   state => {

--- a/src/components/ErrorBox.js
+++ b/src/components/ErrorBox.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Radium from 'radium';
+import {connect} from 'react-redux';
+import {styles} from './styles';
+
+export class ErrorBox extends React.Component {
+  render() {
+    switch(false) {
+      case typeof this.props.loadApiError === "undefined":
+        return (
+          <span style={styles.errorBox}>
+              {this.props.loadApiError.message}
+          </span>
+        );
+      case typeof this.props.runCodeError === "undefined":
+        return (
+          <span style={styles.errorBox}>
+              {this.props.runCodeError.message}
+          </span>
+        );
+      case typeof this.props.googleDriveError === "undefined":
+        return (
+          <span style={styles.errorBox}>
+              {this.props.googleDriveError.message}
+          </span>
+        );
+      default:
+        return null; //if no error recorded in state do nothing
+    }
+  }
+}
+
+ErrorBox.propTypes = {
+  loadApiError: React.PropTypes.string,
+  runCodeError: React.PropTypes.string,
+  googleDriveError: React.PropTypes.string,
+};
+
+export default connect(
+  state => ({
+    loadApiError: state.loadApi.error,
+    runCodeError: state.runCode.error,
+    googleDriveError: state.googleDrive.error,
+  })
+)(Radium(ErrorBox));

--- a/src/components/ErrorBox.js
+++ b/src/components/ErrorBox.js
@@ -2,44 +2,21 @@ import React from 'react';
 import Radium from 'radium';
 import {connect} from 'react-redux';
 import {styles} from './styles';
+import {getError} from '../redux/selectors';
 
 export class ErrorBox extends React.Component {
   render() {
-    switch(false) {
-      case typeof this.props.loadApiError === "undefined":
-        return (
-          <span style={styles.errorBox}>
-              {this.props.loadApiError.message}
-          </span>
-        );
-      case typeof this.props.runCodeError === "undefined":
-        return (
-          <span style={styles.errorBox}>
-              {this.props.runCodeError.message}
-          </span>
-        );
-      case typeof this.props.googleDriveError === "undefined":
-        return (
-          <span style={styles.errorBox}>
-              {this.props.googleDriveError.message}
-          </span>
-        );
-      default:
-        return null; //if no error recorded in state do nothing
+    if (this.props.error) {
+      return <span style={styles.errorBox}>{this.props.error.message}</span>;
     }
+    return null;
   }
 }
 
 ErrorBox.propTypes = {
-  loadApiError: React.PropTypes.string,
-  runCodeError: React.PropTypes.string,
-  googleDriveError: React.PropTypes.string,
+  error: React.PropTypes.object,
 };
 
 export default connect(
-  state => ({
-    loadApiError: state.loadApi.error,
-    runCodeError: state.runCode.error,
-    googleDriveError: state.googleDrive.error,
-  })
+  state => ({error: getError(state)})
 )(Radium(ErrorBox));

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -1,4 +1,16 @@
 export var styles = {
+  errorBox: {
+    fontFamily: "sans-serif",
+    border: 1,
+    borderColor: "#FF3131",
+    borderStyle: "dashed",
+    padding: 3,
+    borderRadius: 3,
+    background: "#FFF2F2",
+    position: "relative",
+    top: 8,
+    left: 6,
+  },
   logo: {
     height: "80%",
     paddingLeft: 15,

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -40,7 +40,8 @@ function editor(state = initialState.editor, action) {
 function loadApi(state = initialState.loadApi, action) {
   switch (action.type) {
     case actType.START_LOAD_RUNTIME:
-      return Object.assign({}, state, {stage: constants.loadApiStages.STARTED});
+      return Object.assign({}, state, {stage: constants.LoadApiStages.STARTED,
+                                       error: undefined});
     case actType.FINISH_LOAD_RUNTIME:
       return Object.assign({}, state, {stage: constants.loadApiStages.FINISHED,
                                        runtime: action.payload});
@@ -55,7 +56,8 @@ function loadApi(state = initialState.loadApi, action) {
 function runCode(state = initialState.runCode, action) {
   switch (action.type) {
     case actType.START_PARSE:
-      return Object.assign({}, state, {stage: constants.runtimeStages.PARSING});
+      return Object.assign({}, state, {stage: constants.runtimeStages.PARSING,
+                                       error: undefined});
     case actType.FINISH_PARSE:
       return Object.assign({}, state, {stage: null, ast: action.payload});
     case actType.FAIL_PARSE:
@@ -88,7 +90,8 @@ function googleDrive(state = initialState.googleDrive, action) {
   switch (action.type) {
     case actType.START_CONNECT_DRIVE:
       return Object.assign({}, state, {
-        stage: constants.driveStages.connect.STARTED
+        stage: constants.GDriveStages.connect.STARTED,
+        error: undefined,
       });
     case actType.FINISH_CONNECT_DRIVE:
       return Object.assign({}, state, {
@@ -131,7 +134,6 @@ function googleDrive(state = initialState.googleDrive, action) {
       return state;
   }
 }
-
 
 const pyretReducer = combineReducers({
   loadApi,

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -40,8 +40,8 @@ function editor(state = initialState.editor, action) {
 function loadApi(state = initialState.loadApi, action) {
   switch (action.type) {
     case actType.START_LOAD_RUNTIME:
-      return Object.assign({}, state, {stage: constants.LoadApiStages.STARTED,
-                                       error: undefined});
+      return Object.assign({}, state, {stage: constants.loadApiStages.STARTED,
+                                       error: null});
     case actType.FINISH_LOAD_RUNTIME:
       return Object.assign({}, state, {stage: constants.loadApiStages.FINISHED,
                                        runtime: action.payload});
@@ -57,7 +57,7 @@ function runCode(state = initialState.runCode, action) {
   switch (action.type) {
     case actType.START_PARSE:
       return Object.assign({}, state, {stage: constants.runtimeStages.PARSING,
-                                       error: undefined});
+                                       error: null});
     case actType.FINISH_PARSE:
       return Object.assign({}, state, {stage: null, ast: action.payload});
     case actType.FAIL_PARSE:
@@ -90,8 +90,8 @@ function googleDrive(state = initialState.googleDrive, action) {
   switch (action.type) {
     case actType.START_CONNECT_DRIVE:
       return Object.assign({}, state, {
-        stage: constants.GDriveStages.connect.STARTED,
-        error: undefined,
+        stage: constants.driveStages.connect.STARTED,
+        error: null,
       });
     case actType.FINISH_CONNECT_DRIVE:
       return Object.assign({}, state, {

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -5,7 +5,7 @@ export function isRunning(state) {
 }
 
 export function isLoadingRuntime(state) {
-  return (Object.values(constants.loadApiStages).includes(state.loadApi.stage));
+  return (state.loadApi.stage === constants.loadApiStages.STARTED);
 }
 
 export function hasLoadedRuntime(state) {


### PR DESCRIPTION
the reducers had to be updated to initialize their respective error states to undefined because otherwise when an action was dispatched it wouldn't matter if the user had fixed the mistake/error (like not giving any source code), the error would still show, forcing them to have to refresh the page instead of just carrying on

PS: This is what the error message looks like

![error](https://cloud.githubusercontent.com/assets/17171674/16570776/6b86c25c-4201-11e6-9b62-8f647d7bf17e.png)
